### PR TITLE
Remove call to logging.basicConfig()

### DIFF
--- a/ubiconfig/ubi.py
+++ b/ubiconfig/ubi.py
@@ -11,7 +11,6 @@ from .utils.api.gitlab import RepoApi
 
 DEFAULT_UBI_REPO = os.getenv("DEFAULT_UBI_REPO", "")
 
-logging.basicConfig()
 LOG = logging.getLogger('ubiconfig')
 
 


### PR DESCRIPTION
logging.basicConfig() is something which can only be done once
per process.

Simply importing a library shouldn't have the side-effect of
calling this. It means for example that a command-line tool's
call to logging.basicConfig with some arguments will be ignored;
and if multiple libraries do this with different arguments, it
means log behavior mysteriously changes depending on the order
in which modules are imported.