### PR TITLE
Drop unnecessary requests version range

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 six
-# Old python needs reqests<=2.18
-requests<=2.18.4; python_version<'3'
-requests; python_version>='3'
+requests
 jsonschema==2.5.1
 # Old Python needs old PyYAML
 PyYAML<3.12; python_version<'3'


### PR DESCRIPTION
This shouldn't be needed, as requests package defines
the supported Python versions in its metadata.

The motivation for removing the unnecessary version range is to
address the vulnerability alert github has raised for the package.