### PR TITLE
Minor refactor & raise coverage to 100%

### DIFF
--- a/tests/ubiconfig/test_ubi.py
+++ b/tests/ubiconfig/test_ubi.py
@@ -69,6 +69,17 @@ def test_load_from_local():
     assert isinstance(config, ubi.UbiConfig)
 
 
+def test_load_from_nonyaml(tmpdir):
+    somefile = tmpdir.join('some-file.txt')
+    somefile.write('[oops, this is not valid yaml')
+
+    loader = ubi.get_loader(local=True)
+
+    # The exception from failing to load this file should be propagated
+    with pytest.raises(yaml.YAMLError):
+        loader.load(str(somefile))
+
+
 def test_load_all_from_local():
     repo = os.path.join(TEST_DATA_DIR, 'configs/dnf7')
     loader = ubi.get_loader(local=True, local_repo=repo)

--- a/ubiconfig/ubi.py
+++ b/ubiconfig/ubi.py
@@ -118,26 +118,27 @@ class Loader(object):
               b. or load all config files from a local_repo
               ##TODO: make it git aware
         """
-        if not self.local:
-            # find the right branch from the mapping
-            branch = self.files_branch_map[file_name]
-            config_file_url = self.repo_api.get_file_content_api(file_name, branch)
-            LOG.info("Loading configuration file from remote: %s", file_name)
-            response = self.session.get(config_file_url)
-            response.raise_for_status()
-            try:
+        try:
+            if not self.local:
+                # find the right branch from the mapping
+                branch = self.files_branch_map[file_name]
+                config_file_url = self.repo_api.get_file_content_api(file_name, branch)
+                LOG.info("Loading configuration file from remote: %s", file_name)
+                response = self.session.get(config_file_url)
+                response.raise_for_status()
                 config_dict = yaml.safe_load(response.content)
-            except yaml.YAMLError:
-                LOG.error('There is syntax error in your config file %s, please fix', file_name)
-                raise
-        else:
-            if self.local_repo:
-                file_path = os.path.join(self.local_repo, file_name)
             else:
-                file_path = file_name
-            LOG.info("Loading configuration file locally: %s", file_path)
-            with open(file_path, 'r') as f:
-                config_dict = yaml.safe_load(f)
+                if self.local_repo:
+                    file_path = os.path.join(self.local_repo, file_name)
+                else:
+                    file_path = file_name
+                LOG.info("Loading configuration file locally: %s", file_path)
+                with open(file_path, 'r') as f:
+                    config_dict = yaml.safe_load(f)
+
+        except yaml.YAMLError:
+            LOG.error('There is syntax error in your config file %s, please fix', file_name)
+            raise
 
         # validate input data
         validate_config(config_dict)


### PR DESCRIPTION
When YAML can't be parsed, the library logs a message telling which
file it was attempting to load when it found invalid YAML.

For some reason, that log was only in the remote code path.
There doesn't seem to be any particular reason for that; why wouldn't
you want the same message logged for both remote and local cases?
Refactor to do this & make it tested.