### PR TITLE
 Refactor get_loader, Loader concepts

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ No matter which branch is the config file in, it will load it for you.
     from ubiconfig import get_loader
 
     default_loader = get_loader()
-    config = default_loader.load("ubi7_config_file")
+    config = default_loader.load("ubi7_config_file.yaml")
 
     # the return config is an UbiConfig instance, wraps all types of UBI configurations
     modules = config.modules
@@ -46,7 +46,7 @@ No matter which branch is the config file in, it will load it for you.
 
     # the returned Load object can be reused to load other configuration file in the
     # same repo
-    config = default_loader.load("ubi8_config_file")
+    config = default_loader.load("ubi8_config_file.yaml")
     content_sets = config.content_sets
 
 More Use Cases
@@ -63,67 +63,23 @@ Except the above usage, there are some other use cases:
     configs = loader.load_all()
     # returns a list of UbiConfig objects
 
-2. Load configuration files from a local repo by setting ``local`` to ``True``
+2. Load configuration files from a directory by passing a local path:
 
 .. code-block:: python
 
     from ubiconfig import get_loader
 
-    local_loader = get_loader(local=True)
-    config = local_loader.load("full/path/to/local_ubi7_config")
+    local_loader = get_loader("/my/config/dir")
+    config = local_loader.load("path/to/local_ubi7_config.yaml")
 
-3. If there's a local repo inlcudes several configuration files, you can also set the repo
-path by passing ``local_repo`` to ``get_loader``
-
-.. code-block:: python
-
-    from ubiconfig import get_loader
-
-    local_loader = get_loader(use=True, local_repo='repo/path')
-    config = local_loader.load('local_ubi7_config')
-    # or load all config files
-    configs = local_loader.load_all()
-    # if there's sub directories include configuration files,
-    # user can set ``recursive`` to True to load all of them
+    # or try load_all with recursive to load all available config files
     configs = local_loader.load_all(recursive=True)
 
-You can always reuse the loader
 
 API Reference
 -------------
 .. currentmodule:: ubiconfig
-.. function:: get_loader
-
-    Get a Loader instance which is used to load configurations.
-
-    The default config file source is as ``DEFAULT_UBI_URL/configfile.yaml``,
-    when ``local`` is not set, it will check if the ``DEFAULT_UBI_URL`` is set
-    or not, then creates a requests session and pass it to ``Loader``.
-
-    Or if ``local`` is set, then user can pass the local_repo address to
-    Loader or send full path to ``loader.load()``, for example:
-
-    .. code-block:: python
-
-      # use default config source
-      >>> loader = get_loader()
-      >>> config_ubi7 = loader.load('ubi7')
-      >>> config)ubi7.content_sets.rpm.input
-      # loader can be used repeatedly
-      >>> config_ubi8 = loader.load('ubi8')
-
-      # now use local file
-      >>> loader = get_loader(use_local=True)
-      >>> config = loader.load('full/path/to/configfile')
-
-      # can pass local repo address as well
-      >>> loader = get_loader(use_local=True, local_repo='some/repo/path')
-      >>> config = loader.load('ubi7')
-      # can be reused
-      >>> config_ubi8 = loader.load('ubi8')
-
-    If the default ubi url is not defined and use_local not set, error will
-    be raised.
+.. autofunction:: get_loader
 
 .. autoclass:: UbiConfig
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 def get_description():
@@ -24,10 +24,7 @@ setup(
     version='0.1.0',
     author='',
     author_email='',
-    packages=['ubiconfig',
-              'ubiconfig.utils',
-              'ubiconfig.utils.api',
-              'ubiconfig.config_types'],
+    packages=find_packages(exclude=['tests', 'tests.*']),
     package_data={'ubiconfig': ['utils/config_schema.json']},
     url='https://github.com/release-engineering/ubi-config',
     license='GNU General Public License',

--- a/tests/ubiconfig/loaders/test_gitlab_loader.py
+++ b/tests/ubiconfig/loaders/test_gitlab_loader.py
@@ -1,0 +1,32 @@
+from mock import patch, MagicMock, Mock
+import pytest
+import yaml
+
+from ubiconfig._impl.loaders import GitlabLoader
+
+
+def mock_json(value):
+    out = MagicMock()
+    out.json.return_value = value
+    return out
+
+
+def test_bad_yaml():
+    with patch('requests.Session') as mock_session_class:
+        session = mock_session_class.return_value
+        session.get.side_effect = [
+            # branches
+            mock_json([{'name': 'master'}]),
+
+            # files
+            mock_json([{'name': 'badfile.yaml', 'path': 'badfile.yaml'}]),
+
+            # content (not valid yaml!)
+            Mock(content='[oops not yaml'),
+        ]
+
+        loader = GitlabLoader('https://some-repo.example.com/foo/bar')
+
+        # It should propagate the YAML load exception
+        with pytest.raises(yaml.YAMLError):
+            loader.load('badfile.yaml')

--- a/tests/ubiconfig/loaders/test_loader.py
+++ b/tests/ubiconfig/loaders/test_loader.py
@@ -1,0 +1,15 @@
+from pytest import raises
+
+from ubiconfig import Loader
+
+
+def test_no_load():
+    """load must be implemented in subclass"""
+    with raises(NotImplementedError):
+        Loader().load('something.yaml')
+
+
+def test_no_load_all():
+    """load_all must be implemented in subclass"""
+    with raises(NotImplementedError):
+        Loader().load_all()

--- a/tests/ubiconfig/test_ubi.py
+++ b/tests/ubiconfig/test_ubi.py
@@ -4,8 +4,7 @@ import pytest
 from mock import patch
 import yaml
 
-from ubiconfig import ubi
-from ubiconfig.utils.api.gitlab import RepoApi
+from ubiconfig import ubi, UbiConfig
 
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), '../data')
@@ -47,57 +46,56 @@ def response():
 
 
 @patch('requests.Session')
-@patch('ubiconfig.ubi.Loader._pre_load')
+@patch('ubiconfig._impl.loaders.GitlabLoader._pre_load')
 def test_load_all_from_default_repo(mocked_pre_load, mocked_session, files_branch_map,
                                     dnf7_config_file, ubi7_config_file, response):
     mocked_pre_load.return_value = files_branch_map
-    mocked_session.return_value.get.side_effect = ['200 OK',
-                                                   response(dnf7_config_file),
+    mocked_session.return_value.get.side_effect = [response(dnf7_config_file),
                                                    response(ubi7_config_file)]
     loader = ubi.get_loader()
     configs = loader.load_all()
     configs = sorted(configs, key=repr)
     assert len(configs) == 2
-    assert isinstance(configs[0], ubi.UbiConfig)
+    assert isinstance(configs[0], UbiConfig)
     assert str(configs[1]) == 'rhel-atomic-host.yaml'
 
 
 def test_load_from_local():
-    loader = ubi.get_loader(local=True)
-    # pass the complete path to load
-    config = loader.load(os.path.join(TEST_DATA_DIR, 'configs/dnf7/rhel-atomic-host.yaml'))
-    assert isinstance(config, ubi.UbiConfig)
+    loader = ubi.get_loader(TEST_DATA_DIR)
+    # loads relative to given path
+    config = loader.load('configs/dnf7/rhel-atomic-host.yaml')
+    assert isinstance(config, UbiConfig)
 
 
 def test_load_from_nonyaml(tmpdir):
     somefile = tmpdir.join('some-file.txt')
     somefile.write('[oops, this is not valid yaml')
 
-    loader = ubi.get_loader(local=True)
+    loader = ubi.get_loader(str(tmpdir))
 
     # The exception from failing to load this file should be propagated
     with pytest.raises(yaml.YAMLError):
-        loader.load(str(somefile))
+        loader.load('some-file.txt')
 
 
 def test_load_all_from_local():
     repo = os.path.join(TEST_DATA_DIR, 'configs/dnf7')
-    loader = ubi.get_loader(local=True, local_repo=repo)
+    loader = ubi.get_loader(repo)
     configs = loader.load_all()
     assert len(configs) == 1
-    assert isinstance(configs[0], ubi.UbiConfig)
+    assert isinstance(configs[0], UbiConfig)
 
 
 def test_load_all_from_local_recursive():
     repo = os.path.join(TEST_DATA_DIR, 'configs')
-    loader = ubi.get_loader(local=True, local_repo=repo)
+    loader = ubi.get_loader(repo)
     configs = loader.load_all(recursive=True)
     assert len(configs) == 2
-    assert isinstance(configs[0], ubi.UbiConfig)
+    assert isinstance(configs[0], UbiConfig)
 
 
 def test_syntax_error_from_config_file():
-    loader = ubi.get_loader(local=True, local_repo=TEST_DATA_DIR)
+    loader = ubi.get_loader(TEST_DATA_DIR)
     try:
         loader.load('bad_configs/syntax_error.yaml')
         raise AssertionError('load should fail!')
@@ -105,35 +103,36 @@ def test_syntax_error_from_config_file():
         assert e.problem == "expected <block end>, but found '?'"
 
 
+def test_get_loader_notexist(tmpdir):
+    with pytest.raises(ubi.LoaderError) as exc:
+        ubi.get_loader(str(tmpdir.join("not-exist-dir")))
+
+    assert 'not an existing directory' in str(exc.value)
+
+
 def test_default_or_local_repo_not_set():
-    ubi.DEFAULT_UBI_REPO = ''
-    expected_error = ValueError('Please either set use_local or define \
-DEFAULT_UBI_REPO in your environment')
     try:
-        ubi.get_loader()
-        raise AssertionError('should not get a loader!')
-    except ValueError as e:
-        assert isinstance(e, type(expected_error))
-        assert e.args == expected_error.args
-    ubi.DEFAULT_UBI_REPO = 'https://contentdelivery.com/ubi/data'
+        ubi.DEFAULT_UBI_REPO = ''
 
+        expected_error = ('Please either set a source or define DEFAULT_UBI_REPO '
+                          'in your environment')
 
-def test_load_all_from_local_without_repo_set():
-    loader = ubi.get_loader(local=True)
-    try:
-        loader.load_all()
-        raise AssertionError('should fail!')
-    except RuntimeError as e:
-        assert e.args == ('You need to set local repo to load all files',)
+        with pytest.raises(ubi.LoaderError) as exc:
+            ubi.get_loader()
+
+        assert str(exc.value) == expected_error
+
+    finally:
+        ubi.DEFAULT_UBI_REPO = 'https://contentdelivery.com/ubi/data'
 
 
 @patch('requests.Session')
 def test_get_empty_branches(mocked_session):
-    mocked_session.get.return_value.json.return_value = {}
-    repo_apis = RepoApi(ubi.DEFAULT_UBI_REPO)
-    exception = RuntimeError('Please check your DEFAULT_UBI_REPO is in right format')
+    mocked_session.return_value.get.return_value.json.return_value = {}
+    exception = RuntimeError(('Please check https://contentdelivery.com/ubi/data '
+                              'is in right format'))
     try:
-        ubi.Loader(session=mocked_session, repo_api=repo_apis)
+        ubi.get_loader()
         raise AssertionError('test should fail!')
     except RuntimeError as actual_exception:
         assert actual_exception.args == exception.args
@@ -143,33 +142,30 @@ def test_get_empty_branches(mocked_session):
 def test_get_branches(mocked_session):
     branches = [{'name': 'dnf7', 'default': True, 'can_push': True},
                 {'name': 'ubi7', 'default': False, 'can_push': True}]
-    mocked_session.get.return_value.json.return_value = branches
-    repo_apis = RepoApi(ubi.DEFAULT_UBI_REPO)
-    with patch('ubiconfig.ubi.Loader._pre_load'):
-        loader = ubi.Loader(session=mocked_session, repo_api=repo_apis)
-        actual_branches = loader._get_branches()
+    mocked_session.return_value.get.return_value.json.return_value = branches
+    loader = ubi.get_loader()
+    actual_branches = loader._get_branches()
     assert actual_branches == ['dnf7', 'ubi7']
 
 
 @patch('requests.Session')
-@patch('ubiconfig.ubi.Loader._get_branches')
+@patch('ubiconfig._impl.loaders.GitlabLoader._get_branches')
 def test_pre_load(mocked_get_branches, mocked_session, files_branch_map):
     branches = ['dnf7', 'ubi7']
     mocked_get_branches.return_value = branches
     file_list = [[{'name': 'rhel-atomic-host.yaml', 'path': 'rhel-atomic-host.yaml'},
                   {'name': 'README.md', 'path': 'README.md'}],
                  [{'name': 'rhel-7-for-power-le.yaml', 'path': 'rhel-7-for-power-le.yaml'}]]
-    mocked_session.get.return_value.json.side_effect = file_list
-    repo_apis = RepoApi(ubi.DEFAULT_UBI_REPO)
-    loader = ubi.Loader(session=mocked_session, repo_api=repo_apis)
+    mocked_session.return_value.get.return_value.json.side_effect = file_list
+    loader = ubi.get_loader()
     expected_map = files_branch_map
-    actual_files_branch_map = loader.files_branch_map
+    actual_files_branch_map = loader._files_branch_map
     assert expected_map == actual_files_branch_map
 
 
 def test_ubi_config(dnf7_config_file):
     config_dict = yaml.safe_load(dnf7_config_file)
-    config = ubi.UbiConfig.load_from_dict(config_dict, 'rhel-atomic-host.yaml')
+    config = UbiConfig.load_from_dict(config_dict, 'rhel-atomic-host.yaml')
     assert config.modules[0].name == 'nodejs'
     assert config.content_sets.rpm.input == 'rhel-atomic-host-rpms'
     assert str(config.packages.blacklist[0]) == 'kernel*'

--- a/ubiconfig/__init__.py
+++ b/ubiconfig/__init__.py
@@ -1,3 +1,5 @@
-from ubiconfig.ubi import get_loader, Loader, UbiConfig
+from ubiconfig.ubi import get_loader
+from ubiconfig._impl.loaders.base import Loader
+from ubiconfig.config_types import UbiConfig
 
 __all__ = ['get_loader', 'Loader', 'UbiConfig']

--- a/ubiconfig/_impl/loaders/__init__.py
+++ b/ubiconfig/_impl/loaders/__init__.py
@@ -1,0 +1,4 @@
+from .gitlab import GitlabLoader
+from .local import LocalLoader
+
+__all__ = ['GitlabLoader', 'LocalLoader']

--- a/ubiconfig/_impl/loaders/base.py
+++ b/ubiconfig/_impl/loaders/base.py
@@ -1,0 +1,28 @@
+class Loader(object):
+    """Load UBI configuration.
+
+    Don't construct instances of this class directly;
+    use the :func:`~ubiconfig.get_loader` function.
+    """
+
+    # This is a base class only. See implementations alongside this one
+    # under the loaders module.
+
+    def load(self, file_name):
+        """
+        Load a single configuration file and return a :class:`UbiConfig` object.
+
+        The given file_name should be a relative path to a YAML file
+        in the loader's config source (e.g. relative path to file within a
+        git repo or local directory).
+        """
+        raise NotImplementedError()
+
+    def load_all(self, recursive=False):
+        """Get the list of config files from repo and call load on every file.
+        Return a list of :class:`UbiConfig` objects.
+
+        If recursive is set, it will walk through the submodules, no matter local
+        or remote
+        """
+        raise NotImplementedError()

--- a/ubiconfig/_impl/loaders/gitlab.py
+++ b/ubiconfig/_impl/loaders/gitlab.py
@@ -1,0 +1,74 @@
+import logging
+import yaml
+import requests
+
+from ubiconfig.utils.api.gitlab import RepoApi
+from ubiconfig.utils.config_validation import validate_config
+from ubiconfig.config_types import UbiConfig
+
+from .base import Loader
+
+LOG = logging.getLogger('ubiconfig')
+
+
+class GitlabLoader(Loader):
+    """Load configuration from a remote repo on gitlab."""
+    def __init__(self, url):
+        self._url = url
+        self._session = requests.Session()
+        self._repo_api = RepoApi(self._url.rstrip('/'))
+        self._files_branch_map = self._pre_load()
+
+    def load(self, file_name):
+        # find the right branch from the mapping
+        branch = self._files_branch_map[file_name]
+
+        config_file_url = self._repo_api.get_file_content_api(file_name, branch)
+        LOG.info("Loading configuration file from remote: %s", file_name)
+        response = self._session.get(config_file_url)
+        response.raise_for_status()
+
+        try:
+            config_dict = yaml.safe_load(response.content)
+        except yaml.YAMLError:
+            LOG.error('There is syntax error in your config file %s, please fix', config_file_url)
+            raise
+
+        # validate input data
+        validate_config(config_dict)
+
+        return UbiConfig.load_from_dict(config_dict, file_name)
+
+    def load_all(self, recursive=False):
+        ubi_configs = []
+        for file in self._files_branch_map:
+            LOG.debug("Now loading %s from branch %s", file, self._files_branch_map[file])
+            ubi_configs.append(self.load(file))
+
+        return ubi_configs
+
+    def _pre_load(self, recursive=False):
+        """Iterate all branches to get a mapping of {file_path: branch,...}
+        """
+        files_branch_map = {}
+        branches = self._get_branches()
+        LOG.info("Loading config files from all branches: %s", branches)
+        for branch in branches:
+            file_list_api = self._repo_api.get_file_list_api(branch=branch,
+                                                             recursive=recursive)
+            json_response = self._session.get(file_list_api).json()
+            file_list = [file['path'] for file in json_response
+                         if file['name'].endswith(('.yaml', '.yml'))]
+            for file in file_list:
+                files_branch_map[file] = branch
+        return files_branch_map
+
+    def _get_branches(self):
+        """Get all the branches of a given repo"""
+        LOG.info("Getting branches of the repo")
+        branches_list_api = self._repo_api.get_branch_list_api()
+        json_response = self._session.get(branches_list_api).json()
+        if not json_response:
+            raise RuntimeError('Please check %s is in right format' % self._url)
+        branches = [b['name'] for b in json_response]
+        return branches

--- a/ubiconfig/_impl/loaders/local.py
+++ b/ubiconfig/_impl/loaders/local.py
@@ -1,0 +1,60 @@
+import logging
+import os
+
+import yaml
+
+from ubiconfig.utils.config_validation import validate_config
+from ubiconfig.config_types import UbiConfig
+
+
+LOG = logging.getLogger('ubiconfig')
+
+
+class LocalLoader(object):
+    """Load configuration from a local directory tree."""
+    def __init__(self, path):
+        self._path = path
+
+    def load(self, file_name):
+        file_path = os.path.join(self._path, file_name)
+        LOG.info("Loading configuration file locally: %s", file_path)
+
+        try:
+            with open(file_path, 'r') as f:
+                config_dict = yaml.safe_load(f)
+
+        except yaml.YAMLError:
+            LOG.error('There is syntax error in your config file %s, please fix', file_name)
+            raise
+
+        # validate input data
+        validate_config(config_dict)
+
+        return UbiConfig.load_from_dict(config_dict, file_name)
+
+    def load_all(self, recursive=False):
+        ubi_configs = []
+
+        file_list = self._get_local_file_list(recursive)
+        for file in file_list:
+            LOG.debug("Now loading %s", file)
+            ubi_configs.append(self.load(file))
+
+        return ubi_configs
+
+    def _get_local_file_list(self, recursive):
+        """
+        Get the config file list from local. If recusive is set, then it would walk
+        through the sub-modules.
+        """
+        LOG.info('Getting the local config file list')
+        file_list = []
+        if recursive:
+            for root, _, files in os.walk(self._path):
+                files = [os.path.join(root, f) for f in files if f.endswith(('.yaml', '.yml'))]
+                file_list.extend(files)
+        else:
+            file_list = [file for file in os.listdir(self._path)
+                         if file.endswith(('yaml', '.yml'))]
+
+        return file_list

--- a/ubiconfig/config_types/__init__.py
+++ b/ubiconfig/config_types/__init__.py
@@ -1,0 +1,37 @@
+from .modules import Modules
+from .packages import Packages
+from .content_sets import ContentSetsMapping
+
+
+class UbiConfig(object):
+    """Wrap all UBI related configurations
+    Examples to access different configurations:
+    Modules:
+      config.modules[0].whitelist[0].name
+    Packages:
+      config.packages.whitelist[0].name
+      config.packages.blacklist[0].name
+    ContentSets:
+      config.content_sets.rpm.input
+      config.content_sets.debuginfo.output"""
+    def __init__(self, cs, pkgs, mds, file_name):
+        self.content_sets = cs
+        self.packages = pkgs
+        self.modules = mds
+        self.file_name = file_name
+
+    def __repr__(self):
+        return self.file_name
+
+    @classmethod
+    def load_from_dict(cls, data, file_name):
+        m_data = Modules.load_from_dict(data.get('modules', {}))
+        pkgs = data.get('packages', {})
+        pkgs_data = Packages(pkgs.get('include', []),
+                             pkgs.get('exclude', []),
+                             data.get('arches', []))
+        cs_map = ContentSetsMapping.load_from_dict(data['content_sets'])
+        # use the simplified file name
+        file_name = file_name.split('/')[-1]
+
+        return cls(cs=cs_map, pkgs=pkgs_data, mds=m_data, file_name=file_name)

--- a/ubiconfig/ubi.py
+++ b/ubiconfig/ubi.py
@@ -1,212 +1,67 @@
 import os
 import logging
 
-import yaml
-import requests
+from six.moves.urllib.parse import urlparse
 
-from .config_types import content_sets, packages, modules
-from .utils.config_validation import validate_config
-from .utils.api.gitlab import RepoApi
+from ._impl.loaders import LocalLoader, GitlabLoader
 
 
 DEFAULT_UBI_REPO = os.getenv("DEFAULT_UBI_REPO", "")
 
-logging.basicConfig()
 LOG = logging.getLogger('ubiconfig')
 
 
-def get_loader(local=False, local_repo=None):
+class LoaderError(RuntimeError):
+    pass
+
+
+def get_loader(source=None):
     """Get a Loader instance which is used to load configurations.
 
-    The default config file source is as DEFAULT_UBI_REPO/configfile.yaml,
-    when use_local is not set, it will check if the DEFAULT_UBI_REPO is set
-    or not, then creates a requests session and pass it to Loader.
+    ``source`` should be provided as one of the following:
 
-    Or if use_local is set, then user can pass the local_repo address to
-    Loader or send full path to loader.load(), for example:
+        URL
+            A URL of a remote git repo containing UBI config files.
+            Currently, only Gitlab is supported.
 
-    # use default config source
-    >>> loader = get_loader()
-    >>> config_ubi7 = loader.load('ubi7')
-    >>> config)ubi7.content_sets.rpm.input
-    # loader can be used repeatedly
-    >>> config_ubi8 = loader.load('ubi8')
+        local path
+            A path to a local directory containing UBI config files.
 
-    # now use local file
-    >>> loader = get_loader(use_local=True)
-    >>> config = loader.load('full/path/to/configfile')
+        :any:`None`
+            If none/omitted, the value of the ``DEFAULT_UBI_REPO``
+            environment variable is used. If this is unset, an
+            exception is raised.
 
-    # can pass local repo address as well
-    >>> loader = get_loader(use_local=True, local_repo='some/repo/path')
-    >>> config = loader.load('ubi7')
-    # can be reused
-    >>> config_ubi8 = loader.load('ubi8')
+    After the loader is constructed, it can be used to load config files
+    when given relative paths to config files.
 
-    If the default ubi url is not defined and use_local not set, error will
-    be raised.
-    ##TODO: possible ssl verification options
+    .. code-block:: python
+
+        # use default config source
+        >>> loader = get_loader()
+        >>> config_ubi7 = loader.load('ubi7.yaml')
+        >>> config_ubi7.content_sets.rpm.input
+        # loader can be used repeatedly
+        >>> config_ubi8 = loader.load('ubi8.yaml')
+
+        # or use a local directory
+        >>> loader = get_loader('/my/config/dir)
+        >>> config = loader.load('path/to/configfile.yaml')
     """
-    if not local:
-        if not DEFAULT_UBI_REPO:
-            msg = 'Please either set use_local or define DEFAULT_UBI_REPO in your environment'
-            raise ValueError(msg)
-        session = requests.Session()
-        repo_apis = RepoApi(DEFAULT_UBI_REPO.rstrip('/'))
-        session.get(repo_apis.api_url)
-        return Loader(session=session, repo_api=repo_apis)
-    else:
-        return Loader(local=True, local_repo=local_repo)
+    if not source:
+        source = DEFAULT_UBI_REPO
 
+    if not source:
+        msg = 'Please either set a source or define DEFAULT_UBI_REPO in your environment'
+        raise LoaderError(msg)
 
-class UbiConfig(object):
-    """Wrap all UBI related configurations
-    Examples to access different configurations:
-    Modules:
-      config.modules[0].whitelist[0].name
-    Packages:
-      config.packages.whitelist[0].name
-      config.packages.blacklist[0].name
-    ContentSets:
-      config.content_sets.rpm.input
-      config.content_sets.debuginfo.output"""
-    def __init__(self, cs, pkgs, mds, file_name):
-        self.content_sets = cs
-        self.packages = pkgs
-        self.modules = mds
-        self.file_name = file_name
+    parsed = urlparse(source)
+    if parsed.netloc:
+        # It's a URL, use the gitlab loader
+        return GitlabLoader(source)
 
-    def __repr__(self):
-        return self.file_name
+    # It should be a local path
+    if not os.path.isdir(source):
+        raise LoaderError("'%s' is not an existing directory" % source)
 
-    @classmethod
-    def load_from_dict(cls, data, file_name):
-        m_data = modules.Modules.load_from_dict(data.get('modules', {}))
-        pkgs = data.get('packages', {})
-        pkgs_data = packages.Packages(pkgs.get('include', []),
-                                      pkgs.get('exclude', []),
-                                      data.get('arches', []))
-        cs_map = content_sets.ContentSetsMapping.load_from_dict(data['content_sets'])
-        # use the simplified file name
-        file_name = file_name.split('/')[-1]
-
-        return cls(cs=cs_map, pkgs=pkgs_data, mds=m_data, file_name=file_name)
-
-
-class Loader(object):
-    """Load configuration from default repo or from local file."""
-    def __init__(self, session=None, repo_api=None, local=False, local_repo=None):
-        self.session = session
-        self.repo_api = repo_api
-        self.local = local
-        self.local_repo = local_repo
-        if not self.local:
-            self.files_branch_map = self._pre_load()
-
-    def load(self, file_name):
-        """
-        Load a single configuration file and return a UbiConfig Object
-
-        Use cases:
-          Remote:
-            1. _pre_load ran in __init__, by passing the file_name to load,
-               it will find the right file in the right branch
-          Local:
-            1. called directly by user without self.local_repo specified:
-              user needs to pass the full path
-            2. called by load_all():
-              a. without defining the self.local_repo, error will be raised
-              b. or load all config files from a local_repo
-              ##TODO: make it git aware
-        """
-        try:
-            if not self.local:
-                # find the right branch from the mapping
-                branch = self.files_branch_map[file_name]
-                config_file_url = self.repo_api.get_file_content_api(file_name, branch)
-                LOG.info("Loading configuration file from remote: %s", file_name)
-                response = self.session.get(config_file_url)
-                response.raise_for_status()
-                config_dict = yaml.safe_load(response.content)
-            else:
-                if self.local_repo:
-                    file_path = os.path.join(self.local_repo, file_name)
-                else:
-                    file_path = file_name
-                LOG.info("Loading configuration file locally: %s", file_path)
-                with open(file_path, 'r') as f:
-                    config_dict = yaml.safe_load(f)
-
-        except yaml.YAMLError:
-            LOG.error('There is syntax error in your config file %s, please fix', file_name)
-            raise
-
-        # validate input data
-        validate_config(config_dict)
-
-        return UbiConfig.load_from_dict(config_dict, file_name)
-
-    def load_all(self, recursive=False):
-        """Get the list of config files from repo and call load on every file.
-        Return a list of UbiConfig objects.
-
-        If recursive is set, it will walk through the submodules, no matter local
-        or remote
-        """
-        ubi_configs = []
-        # if not load from local repo, then self.files_branch_map should be loaded
-        if not self.local:
-            for file in self.files_branch_map:
-                LOG.debug("Now loading %s from branch %s", file, self.files_branch_map[file])
-                ubi_configs.append(self.load(file))
-        else:
-            file_list = self._get_local_file_list(recursive)
-            for file in file_list:
-                LOG.debug("Now loading %s", file)
-                ubi_configs.append(self.load(file))
-
-        return ubi_configs
-
-    def _get_local_file_list(self, recursive=False):
-        """
-        Get the config file list from local. If recusive is set, then it would walk
-        through the sub-modules.
-        """
-        LOG.info('Getting the local config file list')
-        if self.local_repo is None:
-            raise RuntimeError('You need to set local repo to load all files')
-        file_list = []
-        if recursive:
-            for root, _, files in os.walk(self.local_repo):
-                files = [os.path.join(root, f) for f in files if f.endswith(('.yaml', '.yml'))]
-                file_list.extend(files)
-        else:
-            file_list = [file for file in os.listdir(self.local_repo)
-                         if file.endswith(('yaml', '.yml'))]
-
-        return file_list
-
-    def _pre_load(self, recursive=False):
-        """Iterate all branches to get a mapping of {file_path: branch,...}
-        """
-        files_branch_map = {}
-        branches = self._get_branches()
-        LOG.info("Loading config files from all branches: %s", branches)
-        for branch in branches:
-            file_list_api = self.repo_api.get_file_list_api(branch=branch,
-                                                            recursive=recursive)
-            json_response = self.session.get(file_list_api).json()
-            file_list = [file['path'] for file in json_response
-                         if file['name'].endswith(('.yaml', '.yml'))]
-            for file in file_list:
-                files_branch_map[file] = branch
-        return files_branch_map
-
-    def _get_branches(self):
-        """Get all the branches of a given repo"""
-        LOG.info("Getting branches of the repo")
-        branches_list_api = self.repo_api.get_branch_list_api()
-        json_response = self.session.get(branches_list_api).json()
-        if not json_response:
-            raise RuntimeError('Please check your DEFAULT_UBI_REPO is in right format')
-        branches = [b['name'] for b in json_response]
-        return branches
+    return LocalLoader(source)


### PR DESCRIPTION
The new interface is simply:

- get_loader(source=None), where source is a local path or URL
- if source is omitted then use DEFAULT_UBI_REPO

In comparison the old interface of get_loader(local, local_repo)
was messy with a few problems:

---

It had three different "modes": remote repo, local repo, or just
local (meaning absolute paths must be given).

Supporting both the "local repo" and "local" modes doesn't
seem to make much sense to me.  With these two modes, you have to
know whether the loader was created in "local repo" mode or "local"
mode before you know how to use it (because you have to know whether
you're supposed to give relative or absolute paths). So it's hard
to write a function which can take a loader and work regardless of
which data source is used behind the loader.  Let's collapse this
into having only two modes, local and remote, both of which load
files using relative paths.

---

The implementation of all three modes was bundled into
a single Loader class.  The main methods in that class had
different code paths for the different modes, and some methods
only called in certain modes.  This is a natural fit for
implementing in separate classes instead of having the code
together unnecessarily, so let's do that.

---

It was not possible to have DEFAULT_UBI_REPO set to anything other
than a gitlab repo; and it was not possible to use a gitlab repo
by any means other than setting DEFAULT_UBI_REPO. There doesn't
seem to be any reason for such restrictions. It means for instance
you couldn't write code which would normally access a remote repo,
and simply redirect it to a local directory by setting
DEFAULT_UBI_REPO.

Let's just let the caller pass what they want, and use
DEFAULT_UBI_REPO if they haven't passed anything.

---

Lots of internal-only attributes like repo_api were available on
the Loader, with no hints these are not meant for public use.
Make sure they're named with leading _ so it's clear they're
private.
50f7555