### PR TITLE
Add argument 'per_page' and remove 'recursive' in gitlab api

### DIFF
--- a/tests/ubiconfig/loaders/test_gitlab_loader.py
+++ b/tests/ubiconfig/loaders/test_gitlab_loader.py
@@ -25,7 +25,7 @@ def test_bad_yaml():
             Mock(content='[oops not yaml'),
         ]
 
-        loader = GitlabLoader('https://some-repo.example.com/foo/bar')
+        loader = GitlabLoader('https://some-repo.example.com/foo/bar', per_page=30)
 
         # It should propagate the YAML load exception
         with pytest.raises(yaml.YAMLError):

--- a/tests/ubiconfig/utils/test_gitlab_api.py
+++ b/tests/ubiconfig/utils/test_gitlab_api.py
@@ -24,7 +24,7 @@ def test_get_branch_list_api(v4_repo_api, v4_api_prefix):
 
 
 def test_get_file_list_api(v4_repo_api, v4_api_prefix):
-    expected_file_list_api = urljoin(v4_api_prefix, 'repository/tree?ref=master&recursive=False')
+    expected_file_list_api = urljoin(v4_api_prefix, 'repository/tree?ref=master&per_page=30')
     v4_repo_api.get_file_list_api() == expected_file_list_api
 
 

--- a/ubiconfig/_impl/loaders/gitlab.py
+++ b/ubiconfig/_impl/loaders/gitlab.py
@@ -13,11 +13,11 @@ LOG = logging.getLogger('ubiconfig')
 
 class GitlabLoader(Loader):
     """Load configuration from a remote repo on gitlab."""
-    def __init__(self, url):
+    def __init__(self, url, per_page):
         self._url = url
         self._session = requests.Session()
         self._repo_api = RepoApi(self._url.rstrip('/'))
-        self._files_branch_map = self._pre_load()
+        self._files_branch_map = self._pre_load(per_page)
 
     def load(self, file_name):
         # find the right branch from the mapping
@@ -47,7 +47,7 @@ class GitlabLoader(Loader):
 
         return ubi_configs
 
-    def _pre_load(self, recursive=False):
+    def _pre_load(self, per_page):
         """Iterate all branches to get a mapping of {file_path: branch,...}
         """
         files_branch_map = {}
@@ -55,7 +55,7 @@ class GitlabLoader(Loader):
         LOG.info("Loading config files from all branches: %s", branches)
         for branch in branches:
             file_list_api = self._repo_api.get_file_list_api(branch=branch,
-                                                             recursive=recursive)
+                                                             per_page=per_page)
             json_response = self._session.get(file_list_api).json()
             file_list = [file['path'] for file in json_response
                          if file['name'].endswith(('.yaml', '.yml'))]

--- a/ubiconfig/ubi.py
+++ b/ubiconfig/ubi.py
@@ -15,7 +15,7 @@ class LoaderError(RuntimeError):
     pass
 
 
-def get_loader(source=None):
+def get_loader(source=None, per_page=30):
     """Get a Loader instance which is used to load configurations.
 
     ``source`` should be provided as one of the following:
@@ -31,6 +31,10 @@ def get_loader(source=None):
             If none/omitted, the value of the ``DEFAULT_UBI_REPO``
             environment variable is used. If this is unset, an
             exception is raised.
+
+    ``per_page`` specifies the maximum number of files returned by load_all(),
+    and it's defaulted to 30.
+    It's only functional when load from remote repo
 
     After the loader is constructed, it can be used to load config files
     when given relative paths to config files.
@@ -58,7 +62,7 @@ def get_loader(source=None):
     parsed = urlparse(source)
     if parsed.netloc:
         # It's a URL, use the gitlab loader
-        return GitlabLoader(source)
+        return GitlabLoader(source, per_page)
 
     # It should be a local path
     if not os.path.isdir(source):

--- a/ubiconfig/utils/api/gitlab.py
+++ b/ubiconfig/utils/api/gitlab.py
@@ -38,12 +38,13 @@ or set GIT_LAB_URL_FMT by yourself")
     def get_branch_list_api(self):
         return urljoin(self.api_url, 'repository/branches')
 
-    def get_file_list_api(self, branch=None, recursive=False):
+    def get_file_list_api(self, branch=None, per_page=30):
         """Return the api used to get the list of files in the repo or files
         in the sub-module.
+        The defualt maximum number of return files is 30
         """
         branch = branch.replace('/', '%2F') if branch else 'master'
-        return urljoin(self.api_url, 'repository/tree?ref=%s&recursive=%s' % (branch, recursive))
+        return urljoin(self.api_url, 'repository/tree?ref=%s&per_page=%s' % (branch, per_page))
 
     def get_file_content_api(self, file_path, branch=None):
         """Get the api used to retrieve the raw content.


### PR DESCRIPTION
In GitlabLoader, as configuration files are stored without sub-modules, so recursive is useless. Also, it's possible that there can be more than 20 files in one branch, we add per_page argument to get_loader function, make the maximum number of files returned the gitlab list files api editable. 