### PR TITLE
Use branch commit id instead of name to load files fixes: #15

### DIFF
--- a/tests/ubiconfig/loaders/test_gitlab_loader.py
+++ b/tests/ubiconfig/loaders/test_gitlab_loader.py
@@ -16,7 +16,8 @@ def test_bad_yaml():
         session = mock_session_class.return_value
         session.get.side_effect = [
             # branches
-            mock_json([{'name': 'master'}]),
+            mock_json([{'name': 'master',
+                        'commit': {'id': '2189cbc2e447f796fe354f8d784d76b0a2620248'}}]),
 
             # files
             mock_json([{'name': 'badfile.yaml', 'path': 'badfile.yaml'}]),

--- a/tests/ubiconfig/test_ubi.py
+++ b/tests/ubiconfig/test_ubi.py
@@ -34,8 +34,8 @@ def ubi7_config_file():
 
 @pytest.fixture
 def files_branch_map():
-    return {'rhel-atomic-host.yaml': 'dnf7',
-            'rhel-7-for-power-le.yaml': 'ubi7'}
+    return {'rhel-atomic-host.yaml': 'c99cb8d7dae2e78e8cc7e720d3f950d1c5a0b51f',
+            'rhel-7-for-power-le.yaml': '2189cbc2e447f796fe354f8d784d76b0a2620248'}
 
 
 @pytest.fixture
@@ -140,18 +140,22 @@ def test_get_empty_branches(mocked_session):
 
 @patch('requests.Session')
 def test_get_branches(mocked_session):
-    branches = [{'name': 'dnf7', 'default': True, 'can_push': True},
-                {'name': 'ubi7', 'default': False, 'can_push': True}]
+    branches = [{'name': 'dnf7',
+                 'commit': {'id': 'c99cb8d7dae2e78e8cc7e720d3f950d1c5a0b51f'}},
+                {'name': 'ubi7',
+                 'commit': {'id': '2189cbc2e447f796fe354f8d784d76b0a2620248'}}]
     mocked_session.return_value.get.return_value.json.return_value = branches
     loader = ubi.get_loader()
     actual_branches = loader._get_branches()
-    assert actual_branches == ['dnf7', 'ubi7']
+    assert actual_branches == ['c99cb8d7dae2e78e8cc7e720d3f950d1c5a0b51f',
+                               '2189cbc2e447f796fe354f8d784d76b0a2620248']
 
 
 @patch('requests.Session')
 @patch('ubiconfig._impl.loaders.GitlabLoader._get_branches')
 def test_pre_load(mocked_get_branches, mocked_session, files_branch_map):
-    branches = ['dnf7', 'ubi7']
+    branches = ['c99cb8d7dae2e78e8cc7e720d3f950d1c5a0b51f',
+                '2189cbc2e447f796fe354f8d784d76b0a2620248']
     mocked_get_branches.return_value = branches
     file_list = [[{'name': 'rhel-atomic-host.yaml', 'path': 'rhel-atomic-host.yaml'},
                   {'name': 'README.md', 'path': 'README.md'}],

--- a/ubiconfig/_impl/loaders/gitlab.py
+++ b/ubiconfig/_impl/loaders/gitlab.py
@@ -70,5 +70,5 @@ class GitlabLoader(Loader):
         json_response = self._session.get(branches_list_api).json()
         if not json_response:
             raise RuntimeError('Please check %s is in right format' % self._url)
-        branches = [b['name'] for b in json_response]
+        branches = [b['commit']['id'] for b in json_response]
         return branches


### PR DESCRIPTION
Use branch name to load files could lead to some unexpected errors
in some cases, such as branch name changes during loading.