### PR TITLE
Make GitlabLoader iterate all pages if needed [fixes #16]

### DIFF
--- a/tests/ubiconfig/loaders/test_gitlab_loader.py
+++ b/tests/ubiconfig/loaders/test_gitlab_loader.py
@@ -5,9 +5,11 @@ import yaml
 from ubiconfig._impl.loaders import GitlabLoader
 
 
-def mock_json(value):
+def mock_json(value, headers=None):
     out = MagicMock()
     out.json.return_value = value
+    if headers:
+        out.headers = headers
     return out
 
 
@@ -19,14 +21,17 @@ def test_bad_yaml():
             mock_json([{'name': 'master',
                         'commit': {'id': '2189cbc2e447f796fe354f8d784d76b0a2620248'}}]),
 
-            # files
-            mock_json([{'name': 'badfile.yaml', 'path': 'badfile.yaml'}]),
+            # files and headers
+            mock_json([{'name': 'badfile.yaml', 'path': 'badfile.yaml'}],
+                      {'Content-Length': '629', 'X-Total-Pages': '2', 'X-Per-Page': '20'}),
+
+            mock_json([{'name': 'badfile1.yaml', 'path': 'badfile1.yaml'}],
+                      {'Content-Length': '629', 'X-Total-Pages': '2', 'X-Per-Page': '20'}),
 
             # content (not valid yaml!)
             Mock(content='[oops not yaml'),
         ]
-
-        loader = GitlabLoader('https://some-repo.example.com/foo/bar', per_page=30)
+        loader = GitlabLoader('https://some-repo.example.com/foo/bar')
 
         # It should propagate the YAML load exception
         with pytest.raises(yaml.YAMLError):

--- a/tests/ubiconfig/test_ubi.py
+++ b/tests/ubiconfig/test_ubi.py
@@ -144,6 +144,8 @@ def test_get_branches(mocked_session):
                  'commit': {'id': 'c99cb8d7dae2e78e8cc7e720d3f950d1c5a0b51f'}},
                 {'name': 'ubi7',
                  'commit': {'id': '2189cbc2e447f796fe354f8d784d76b0a2620248'}}]
+    headers = {'Content-Length': '629', 'X-Total-Pages': '1', 'X-Per-Page': '20'}
+    mocked_session.return_value.get.return_value.headers = headers
     mocked_session.return_value.get.return_value.json.return_value = branches
     loader = ubi.get_loader()
     actual_branches = loader._get_branches()
@@ -157,6 +159,8 @@ def test_pre_load(mocked_get_branches, mocked_session, files_branch_map):
     branches = ['c99cb8d7dae2e78e8cc7e720d3f950d1c5a0b51f',
                 '2189cbc2e447f796fe354f8d784d76b0a2620248']
     mocked_get_branches.return_value = branches
+    headers = {'Content-Length': '629', 'X-Total-Pages': '1', 'X-Per-Page': '20'}
+    mocked_session.return_value.get.return_value.headers = headers
     file_list = [[{'name': 'rhel-atomic-host.yaml', 'path': 'rhel-atomic-host.yaml'},
                   {'name': 'README.md', 'path': 'README.md'}],
                  [{'name': 'rhel-7-for-power-le.yaml', 'path': 'rhel-7-for-power-le.yaml'}]]

--- a/tests/ubiconfig/utils/test_gitlab_api.py
+++ b/tests/ubiconfig/utils/test_gitlab_api.py
@@ -24,8 +24,8 @@ def test_get_branch_list_api(v4_repo_api, v4_api_prefix):
 
 
 def test_get_file_list_api(v4_repo_api, v4_api_prefix):
-    expected_file_list_api = urljoin(v4_api_prefix, 'repository/tree?ref=master&per_page=30')
-    v4_repo_api.get_file_list_api() == expected_file_list_api
+    expected_file_list_api = urljoin(v4_api_prefix, 'repository/tree?ref=master&page=1')
+    v4_repo_api.get_file_list_api(page=1) == expected_file_list_api
 
 
 def test_file_content_api(v4_repo_api, v4_api_prefix):

--- a/ubiconfig/ubi.py
+++ b/ubiconfig/ubi.py
@@ -15,7 +15,7 @@ class LoaderError(RuntimeError):
     pass
 
 
-def get_loader(source=None, per_page=30):
+def get_loader(source=None):
     """Get a Loader instance which is used to load configurations.
 
     ``source`` should be provided as one of the following:
@@ -31,10 +31,6 @@ def get_loader(source=None, per_page=30):
             If none/omitted, the value of the ``DEFAULT_UBI_REPO``
             environment variable is used. If this is unset, an
             exception is raised.
-
-    ``per_page`` specifies the maximum number of files returned by load_all(),
-    and it's defaulted to 30.
-    It's only functional when load from remote repo
 
     After the loader is constructed, it can be used to load config files
     when given relative paths to config files.
@@ -62,7 +58,7 @@ def get_loader(source=None, per_page=30):
     parsed = urlparse(source)
     if parsed.netloc:
         # It's a URL, use the gitlab loader
-        return GitlabLoader(source, per_page)
+        return GitlabLoader(source)
 
     # It should be a local path
     if not os.path.isdir(source):

--- a/ubiconfig/utils/api/gitlab.py
+++ b/ubiconfig/utils/api/gitlab.py
@@ -38,13 +38,13 @@ or set GIT_LAB_URL_FMT by yourself")
     def get_branch_list_api(self):
         return urljoin(self.api_url, 'repository/branches')
 
-    def get_file_list_api(self, branch=None, per_page=30):
+    def get_file_list_api(self, page, branch=None):
         """Return the api used to get the list of files in the repo or files
         in the sub-module.
         The defualt maximum number of return files is 30
         """
         branch = branch.replace('/', '%2F') if branch else 'master'
-        return urljoin(self.api_url, 'repository/tree?ref=%s&per_page=%s' % (branch, per_page))
+        return urljoin(self.api_url, 'repository/tree?ref=%s&page=%s' % (branch, page))
 
     def get_file_content_api(self, file_path, branch=None):
         """Get the api used to retrieve the raw content.


### PR DESCRIPTION
Instead of specifying the argument of 'per_page', now the remote loader
will iterate all the pages to load all config files if there's more than one page
in the repository.