### PR TITLE
Get rid of jsonschema version lock [fixes #22]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 six
 requests
-jsonschema==2.5.1
+# Old Python needs old jsonschema
+jsonschema<=2.5.1; python_version<'2.7'
+jsonschema; python_version>='2.7'
 # Old Python needs old PyYAML
 PyYAML<3.12; python_version<'3'
 # New Python can use newest PyYAML
 PyYAML; python_version>='3'
-ordereddict; python_version<'2.7'


### PR DESCRIPTION
It's not reasonable to lock jsonschema version to a fixed one, which
could lead to compability issues.