### PR TITLE
More reasonable __repr__ behavior for Module and Package [fix #26]

### DIFF
--- a/tests/ubiconfig/config_types/test_config_types.py
+++ b/tests/ubiconfig/config_types/test_config_types.py
@@ -18,10 +18,10 @@ def test_pack_with_dot():
     pkg = packages.Package(pkg_info, arches)
     assert pkg.name == 'python2.7'
     assert pkg.arch is None
-    assert repr(pkg) == 'python2.7'
+    assert repr(pkg) == '<Package: python2.7>'
 
 
-def test_while_list_package():
+def test_white_list_package():
     """If it's a whilelist package, then the format <name>*.<arch> is not allowed
     """
     pkg_info = 'kernel*'
@@ -56,7 +56,7 @@ def test_modules():
     assert md[0].stream == '8'
     assert md[0].profiles == ['interpreter']
     assert md[1].stream == '10'
-    assert repr(md[1]) == 'nodejs'
+    assert repr(md[1]) == '<Module: nodejs>'
 
 
 def test_content_sets():

--- a/tests/ubiconfig/test_ubi.py
+++ b/tests/ubiconfig/test_ubi.py
@@ -176,4 +176,4 @@ def test_ubi_config(dnf7_config_file):
     config = UbiConfig.load_from_dict(config_dict, 'rhel-atomic-host.yaml')
     assert config.modules[0].name == 'nodejs'
     assert config.content_sets.rpm.input == 'rhel-atomic-host-rpms'
-    assert str(config.packages.blacklist[0]) == 'kernel*'
+    assert str(config.packages.blacklist[0]) == '<Package: kernel*>'

--- a/ubiconfig/config_types/modules.py
+++ b/ubiconfig/config_types/modules.py
@@ -9,7 +9,7 @@ class Module(object):
         self.profiles = profiles
 
     def __repr__(self):
-        return self.name
+        return '<Module: %s>' % self.name
 
 
 class Modules(object):

--- a/ubiconfig/config_types/packages.py
+++ b/ubiconfig/config_types/packages.py
@@ -13,7 +13,7 @@ class Package(object):
             self.arch = None
 
     def __repr__(self):
-        return self.package
+        return "<Package: %s>" % self.package
 
 
 class IncludePackage(Package):


### PR DESCRIPTION
Previously, __repr__ returns a plain string of the name of module
or package, which could mislead user think it's not an object.
Improve the __repr__ behavior to avoid the confusion.