### PR TITLE
Fix ubi config validation doesn't really validate

### DIFF
--- a/tests/ubiconfig/utils/test_validation.py
+++ b/tests/ubiconfig/utils/test_validation.py
@@ -1,14 +1,50 @@
 import os
 
 import yaml
+import pytest
 
+from jsonschema.exceptions import ValidationError
 from ubiconfig.utils import config_validation
 
 TEST_DATA = os.path.join(os.path.dirname(__file__),
                          '../../data/configs/dnf7/rhel-atomic-host.yaml')
 
 
-def test_validate_data():
+@pytest.fixture
+def dnf7_config():
     with open(TEST_DATA) as f:
         config = yaml.safe_load(f)
-    assert config_validation.validate_config(config) is None
+    return config
+
+
+def test_validate_data_pass(dnf7_config):
+    assert config_validation.validate_config(dnf7_config) is None
+
+
+def test_validate_data_pass_without_module(dnf7_config):
+    dnf7_config.pop('modules')
+    assert config_validation.validate_config(dnf7_config) is None
+
+
+def test_validate_failed_missing_content_sets(dnf7_config):
+    dnf7_config.pop('content_sets')
+    with pytest.raises(ValidationError):
+        config_validation.validate_config(dnf7_config)
+
+
+def test_validate_failed_extra_keyword(dnf7_config):
+    dnf7_config.update({'extra': 'something should not exist'})
+    with pytest.raises(ValidationError):
+        config_validation.validate_config(dnf7_config)
+
+
+def test_validate_failed_missing_package_include(dnf7_config):
+    dnf7_config['packages'].pop('include')
+    with pytest.raises(ValidationError):
+        config_validation.validate_config(dnf7_config)
+
+
+def test_validate_failed_wrong_data_type(dnf7_config):
+    dnf7_config['packages']['include'] = 'A string'
+    with pytest.raises(ValidationError):
+        config_validation.validate_config(dnf7_config)

--- a/ubiconfig/utils/config_schema.json
+++ b/ubiconfig/utils/config_schema.json
@@ -8,49 +8,62 @@
                 "input": {"type": "string"},
                 "output": {"type": "string"}
                 },
+            "additionalProperties": false,
             "required": ["input", "output"]
             },
         "module": {
             "type": "object",
             "properties": {
                 "name": {"type": "string"},
-                "stream": {"type": "number"},
+                "stream": {"type": ["string", "number"]},
                 "profiles":{"type": "array",
                             "items": {"type": "string"}
                         }
                 },
+            "additionalProperties": false,
             "required": ["name", "stream"]
             }
     },
-    "content_sets": {
-        "debuginfo": {"$ref": "#/definitions/content_sets_base"},
-        "rpm": {"$ref": "#/definitions/content_sets_base"},
-        "srpm": {"$ref": "#/definitions/content_sets_base"}
-    },
-    "arches": {
-        "type": "array",
-        "items": {"type": "string"}
-    },
-    "modules": {
-        "type": "object",
-        "properties": {
-            "include": {
-                "type": "array",
-                "items":{"$ref": "#/definitions/module"}
-                }
+    "properties":{
+        "content_sets": {
+            "type": "object",
+            "properties":{
+                "debuginfo": {"$ref": "#/definitions/content_sets_base"},
+                "rpm": {"$ref": "#/definitions/content_sets_base"},
+                "srpm": {"$ref": "#/definitions/content_sets_base"}
+            },
+            "additionalProperties": false
+        },
+        "arches": {
+            "type": "array",
+            "items": {"type": "string"}
+        },
+        "modules": {
+            "type": "object",
+            "properties": {
+                "include": {
+                    "type": "array",
+                    "items":{"$ref": "#/definitions/module"}
+                    }
+                },
+            "additionalProperties": false
+            },
+        "packages": {
+            "type": "object",
+            "properties": {
+                "include": {
+                    "type": "array",
+                    "items": {"type":"string"}
+                    },
+                "exclude": {
+                    "type": "array",
+                    "items": {"type": "string"}
+                    }
+                },
+            "additionalProperties": false,
+            "required": ["include"]
             }
         },
-    "packages": {
-        "type": "object",
-        "properties": {
-            "include": {
-                "type": "array",
-                "items": {"type":"string"}
-                },
-            "exclude": {
-                "type": "array",
-                "items": {"type": "string"}
-                }
-            }
-        }
+    "additionalProperties": false,
+    "required": ["content_sets", "packages"]
 }


### PR DESCRIPTION
Previously, the keyword 'properities' was missing in the config schema,
while the config schema itself was still valid, it wasn't really used to
validate any incoming data. Fix #29

Add 'packages' and 'content_sets' requirements to json schema, which would
fail the validation if those two blocks of configuration are missing. Fix #28

Set additionalProperites to False, so only the declared properities
are allowed.

Also, make module's stream allows both number and string