### PR TITLE
limit dependency PyYAML version only when python_version < 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ requests
 jsonschema<=2.5.1; python_version<'2.7'
 jsonschema; python_version>='2.7'
 # Old Python needs old PyYAML
-PyYAML<3.12; python_version<'3'
+PyYAML<3.12; python_version<'2.7'
 # New Python can use newest PyYAML
-PyYAML; python_version>='3'
+PyYAML; python_version>='2.7'


### PR DESCRIPTION
Previously, if Python version is older than 3, it would install PyYAML < 3.12.
However, python2.7 is able to use PyYAML newer than 3.12, so only
limit PyYAML version when Python version is older than  2.7 is enough.