### PR TITLE
Fix implicit conversion of data from YAML files

### DIFF
--- a/tests/data/configs/dnf7/rhel-atomic-host.yaml
+++ b/tests/data/configs/dnf7/rhel-atomic-host.yaml
@@ -38,3 +38,5 @@ modules:
   # for nodejs:10, ship all profiles
   - name: nodejs
     stream: 10
+  - name: something-else
+    stream: 1.10

--- a/tests/ubiconfig/test_ubi.py
+++ b/tests/ubiconfig/test_ubi.py
@@ -105,6 +105,12 @@ def test_load_from_local():
     assert isinstance(config, UbiConfig)
 
 
+def test_load_from_local_decimal_integrity():
+    loader = ubi.get_loader(TEST_DATA_DIR)
+    config = loader.load('configs/dnf7/rhel-atomic-host.yaml')
+    assert config.modules.whitelist[2].stream == '1.10'
+
+
 def test_load_from_nonyaml(tmpdir):
     somefile = tmpdir.join('some-file.txt')
     somefile.write('[oops, this is not valid yaml')

--- a/ubiconfig/_impl/loaders/gitlab.py
+++ b/ubiconfig/_impl/loaders/gitlab.py
@@ -30,7 +30,7 @@ class GitlabLoader(Loader):
         response = self._session.get(config_file_url)
         response.raise_for_status()
 
-        config_dict = yaml.safe_load(response.content)
+        config_dict = yaml.load(response.content, Loader=yaml.BaseLoader)
         # validate input data
         validate_config(config_dict)
 

--- a/ubiconfig/_impl/loaders/local.py
+++ b/ubiconfig/_impl/loaders/local.py
@@ -21,7 +21,7 @@ class LocalLoader(object):
         LOG.info("Loading configuration file locally: %s", file_path)
 
         with open(file_path, 'r') as f:
-            config_dict = yaml.safe_load(f)
+            config_dict = yaml.load(f, Loader=yaml.BaseLoader)
         # validate input data
         validate_config(config_dict)
 


### PR DESCRIPTION
To maintain data integrety when loading YAML files, loading is now done
using BaseLoader in stead of SafeLoader. Fixes #34.