### PR TITLE
Explicit dist: trusty in travis.yml for py26 env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
   include:
   - python: "2.6"
     env: TOX_ENV=py26
+    dist: trusty
   - python: "2.7"
     env: TOX_ENV=py27
   - python: "3.5"


### PR DESCRIPTION
The reason is that 'xenial' was made default dist on travis
recently and it does not support python 2.6 anymore.