### PR TITLE
Fix up documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,11 +75,61 @@ Except the above usage, there are some other use cases:
 
 API Reference
 -------------
-
+:mod:`ubiconfig`
+================
 .. currentmodule:: ubiconfig
+
 .. autofunction:: get_loader
 
 .. autoclass:: UbiConfig
+    :members: load_from_dict
 
 .. autoclass:: Loader
     :members: load, load_all
+
+:mod:`ubiconfig.ubi`
+====================
+
+.. currentmodule:: ubiconfig.ubi
+
+.. autoclass:: GitlabLoader
+    :members: load, load_all
+
+.. autoclass:: LocalLoader
+    :members: load, load_all
+
+:mod:`ubiconfig.config_types.packages`
+======================================
+
+.. currentmodule:: ubiconfig.config_types.packages
+.. autoclass:: Packages
+  :members:
+
+:mod:`ubiconfig.config_types.modules`
+=====================================
+
+.. currentmodule:: ubiconfig.config_types.modules
+.. autoclass:: Modules
+    :members: load_from_dict
+
+.. autoclass:: Module
+    :members:
+
+
+:mod:`ubiconfig.config_types.content_sets`
+==========================================
+
+.. currentmodule:: ubiconfig.config_types.content_sets
+.. autoclass:: ContentSetsMapping
+    :members: load_from_dict
+
+.. autoclass:: Rpm
+.. autoclass:: Srpm
+.. autoclass:: Debuginfo
+
+:mod:`ubiconfig.utils.config_validation`
+========================================
+
+.. currentmodule:: ubiconfig.utils.config_validation
+.. autofunction:: validate_config
+.. autodata:: DEFAULT_SCHEMA

--- a/ubiconfig/_impl/loaders/gitlab.py
+++ b/ubiconfig/_impl/loaders/gitlab.py
@@ -16,12 +16,18 @@ LOG = logging.getLogger('ubiconfig')
 class GitlabLoader(Loader):
     """Load configuration from a remote repo on gitlab."""
     def __init__(self, url):
+        """
+        :param url: gitlab repo url in form of `https://<host>/<repo>`
+        """
         self._url = url
         self._session = requests.Session()
         self._repo_api = RepoApi(self._url.rstrip('/'))
         self._files_branch_map = self._pre_load()
 
     def load(self, file_name):
+        """ Load file from remote repository.
+        :param file_name: filename that is on remote repository in any branch
+        """
         # find the right branch from the mapping
         branch = self._files_branch_map[file_name]
 

--- a/ubiconfig/config_types/__init__.py
+++ b/ubiconfig/config_types/__init__.py
@@ -15,6 +15,12 @@ class UbiConfig(object):
       config.content_sets.rpm.input
       config.content_sets.debuginfo.output"""
     def __init__(self, cs, pkgs, mds, file_name):
+        """
+        :param cs: :class:`~ubiconfig.config_types.content_sets.ContentSetsMapping`
+        :param pkgs: :class:`~ubiconfig.config_types.packages.Packages`
+        :param mds: :class:`~ubiconfig.config_types.modules.Modules`
+        :param filename: filename used as identificator
+        """
         self.content_sets = cs
         self.packages = pkgs
         self.modules = mds
@@ -25,6 +31,26 @@ class UbiConfig(object):
 
     @classmethod
     def load_from_dict(cls, data, file_name):
+        """Create new instance of UbiConfig and load it from provided dictonary with
+following format:
+
+    {
+
+        "modules":  ...
+        see :meth:`~ubiconfig.config_types.modules.Modules.load_from_dict` for more info,
+
+        "packages": {
+            "include": [<str>, <str>],
+            "exclude": [<str>, <str>],
+            "arches": [<str>, <str>]
+
+        },
+
+        "content_sets": ...
+        see :meth:`~ubiconfig.config_types.content_sets.ContentSetsMapping.load_from_dict`
+
+    }
+"""
         m_data = Modules.load_from_dict(data.get('modules', {}))
         pkgs = data.get('packages', {})
         pkgs_data = Packages(pkgs.get('include', []),

--- a/ubiconfig/config_types/content_sets.py
+++ b/ubiconfig/config_types/content_sets.py
@@ -2,28 +2,27 @@
 
 
 class ContentSetMapping(object):
-
     def __init__(self, input_content, output_content):
         self.input = input_content
         self.output = output_content
 
 
 class Rpm(ContentSetMapping):
-
+    """Input-output rpm content sets mapping"""
     @property
     def type(self):
         return 'rpm'
 
 
 class Srpm(ContentSetMapping):
-
+    """Input-output srpm content sets mapping"""
     @property
     def type(self):
         return 'srpm'
 
 
 class Debuginfo(ContentSetMapping):
-
+    """Input-output debuginfo content sets mapping"""
     @property
     def type(self):
         return 'debuginfo'
@@ -31,12 +30,33 @@ class Debuginfo(ContentSetMapping):
 
 class ContentSetsMapping(object):
     def __init__(self, rpm, srpm, debuginfo):
+        """
+        Args:
+            rpm(:class:`Rpm`): rpm content sets mapping
+            srpm(:class:`Srpm`): srpm content sets mapping
+            debuginfo(:class:`Debuginfo`): debuginfo content sets mapping
+        """
         self.rpm = rpm
         self.srpm = srpm
         self.debuginfo = debuginfo
 
     @classmethod
     def load_from_dict(cls, data):
+        """create instances of :class:`ContentSetsMapping` from a dictionary
+        Args:
+            data(dict): dictionary with data of following format
+
+.. code-block:: json
+
+        {
+            "rpm": {"input": "input_content_sets",
+                    "output":"output_content_sets"},
+            "srpm": {"input": "input_content_sets",
+                     "output":"output_content_sets"},
+            "debuginfo": {"input": "input_content_sets",
+                          "output":"output_content_sets"}
+        }
+        """
         rpm_data = data.get('rpm', {})
         rpm = Rpm(rpm_data.get('input', ''), rpm_data.get('output', ''))
 

--- a/ubiconfig/config_types/modules.py
+++ b/ubiconfig/config_types/modules.py
@@ -18,7 +18,7 @@ class Modules(object):
     def __init__(self, include):
         """
         Args:
-            include(list): a list of Module instances
+            include(list): a list of :class:`Module` instances
         """
         self.whitelist = include
 
@@ -27,7 +27,20 @@ class Modules(object):
 
     @classmethod
     def load_from_dict(cls, data):
-        """create instances of moudles from a dictionary"""
+        """create instances of :class:`Modules` from a dictionary
+        Args:
+            data(dict): dictionary with data of following format
+
+.. code-block:: json
+
+        {"include": [
+            {
+                "name": "<module_name>",
+                "stream": "<module_stream>",
+                "profiles": "<module_profiles>"
+            }
+        ]}
+        """
         include = []
 
         for item in data.get('include', []):

--- a/ubiconfig/config_types/packages.py
+++ b/ubiconfig/config_types/packages.py
@@ -31,6 +31,12 @@ class ExcludePackage(Package):
 class Packages(object):
 
     def __init__(self, include, exclude, arches):
+        """
+        Args:
+            include(list): list of packages to whitelist
+            exclude(list): list of packages to blacklist
+            arches(list): list of arches of packages in whitelist and blacklist
+        """
         self.whitelist, self.blacklist = [], []
         for package in include:
             self.whitelist.append(IncludePackage(package, arches))

--- a/ubiconfig/ubi.py
+++ b/ubiconfig/ubi.py
@@ -22,11 +22,11 @@ def get_loader(source=None):
 
         URL
             A URL of a remote git repo containing UBI config files.
-            Currently, only Gitlab is supported.
+            Currently, only Gitlab is supported. See :class:`ubiconfig.ubi.GitlabLoader`
 
         local path
             A path to a local directory containing UBI config files.
-
+            See :class:`ubiconfig.ubi.LocalLoader`
         :any:`None`
             If none/omitted, the value of the ``DEFAULT_UBI_REPO``
             environment variable is used. If this is unset, an

--- a/ubiconfig/utils/config_validation.py
+++ b/ubiconfig/utils/config_validation.py
@@ -4,10 +4,13 @@ import json
 from jsonschema import validate
 
 DEFAULT_SCHEMA = os.path.join(os.path.dirname(__file__), "config_schema.json")
+""" Default yaml schema used for validation of UbiConfig configuration files """
 
 
 def validate_config(data, schema=None):
-    """validate the data according to the schema"""
+    """validate the data according to the schema
+
+If no schema is provided, :data:`DEFAULT_SCHEMA` is used"""
     if schema is None:
         with open(DEFAULT_SCHEMA) as f:
             schema = json.load(f)


### PR DESCRIPTION
Closes: #45 

- Added titles for curently referenced module
- documented: load_from_dict fro UbiConfig
    - ubiconfig.ubi.GitlabLoader
    - ubiconfig.ubi.LocalLoader
    - ubiconfig.config_types.packages.Packages
    - ubiconfig.config_types.modules.Modules
    - ubiconfig.config_types.modules.Module
    - ubiconfig.config_types.content_sets.ContentSetsMapping
    - ubiconfig.config_types.content_sets.Rpm
    - ubiconfig.config_types.content_sets.Srpm
    - ubiconfig.config_types.content_sets.DebugInfo
    - ubiconfig.utils.config_validation.validate_config
    - ubiconfig.utils.config_validation.DEFAULT_SCHEMA
- Fix missing refs to classes

