### PR TITLE
Fix get_loader().load() from local couldn't get version correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
 - Make ubiconfig.utils.config_validation.validate_config publicly available via
   ubiconfig.validate_config
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-##[v2.1.0] - 20191-10-23
+## [v2.1.0] - 2019-10-23
 
 ### Fixed
 - Fix LocalLoader couldn't populate version field, now it populates the version field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make ubiconfig.utils.config_validation.validate_config publicly available via
   ubiconfig.validate_config
 
+### Fixed
+- Fix LocalLoader couldn't get right version if the argument version of load() is None.
+
 ## [v2.1.0] - 2019-10-23
 
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="ubi-config",
-    version="2.1.1",
+    version="2.2.0",
     author="",
     author_email="",
     packages=find_packages(exclude=["tests", "tests.*"]),

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="ubi-config",
-    version="2.1.0",
+    version="2.1.1",
     author="",
     author_email="",
     packages=find_packages(exclude=["tests", "tests.*"]),

--- a/tests/ubiconfig/test_ubi.py
+++ b/tests/ubiconfig/test_ubi.py
@@ -181,9 +181,10 @@ def test_load_all_with_error_config(
 
 
 def test_load_from_local():
-    loader = ubi.get_loader(TEST_DATA_DIR)
+    path = os.path.join(TEST_DATA_DIR, "configs/ubi7.1")
+    loader = ubi.get_loader(path)
     # loads relative to given path
-    config = loader.load("configs/ubi7.1/rhel-atomic-host.yaml")
+    config = loader.load("rhel-atomic-host.yaml")
     assert isinstance(config, UbiConfig)
     assert config.version == "7.1"
 

--- a/tests/ubiconfig/test_ubi.py
+++ b/tests/ubiconfig/test_ubi.py
@@ -196,13 +196,13 @@ def test_load_from_local_decimal_integrity():
 
 
 def test_load_from_nonyaml(tmpdir):
-    somefile = tmpdir.join("some-file.txt")
+    somefile = tmpdir.mkdir("ubi7").join("some-file.txt")
     somefile.write("[oops, this is not valid yaml")
 
     loader = ubi.get_loader(str(tmpdir))
 
     with pytest.raises(yaml.YAMLError):
-        loader.load("some-file.txt")
+        loader.load("ubi7/some-file.txt")
 
 
 def test_load_local_failed_validation():
@@ -219,6 +219,13 @@ def test_load_all_from_local():
     assert len(configs) == 2
     assert configs[0].version == "7.1"
     assert isinstance(configs[0], UbiConfig)
+
+
+def test_load_from_directory_not_named_after_ubi():
+    with patch("os.path.isdir"):
+        loader = ubi.get_loader("./ubi7.1a")
+        with pytest.raises(ValueError):
+            config = loader.load("file")
 
 
 def test_load_all_from_local_with_error_configs():

--- a/ubiconfig/_impl/loaders/local.py
+++ b/ubiconfig/_impl/loaders/local.py
@@ -47,8 +47,11 @@ class LocalLoader(object):
 
         if version is None:
             # get version from path, such as configs/ubi7.1/config.yaml, get
-            # ubi7.1
-            version = os.path.basename(os.path.dirname(file_path))
+            # ubi7.1.
+            # In a rare case, either path or filename doesn't include version
+            # info, i.e, pwd is '.', then we get version info by os.getcwd.
+            version = os.path.basename(os.path.dirname(file_path)) \
+                or os.path.basename(os.getcwd())
 
         LOG.info("Loading configuration file locally: %s", file_path)
 

--- a/ubiconfig/_impl/loaders/local.py
+++ b/ubiconfig/_impl/loaders/local.py
@@ -51,9 +51,9 @@ class LocalLoader(object):
             # ubi7.1.
             version = os.path.basename(os.path.dirname(os.path.abspath(file_path)))
 
-        if not re.search(r"ubi[0-9]{1}\.?[0-9]{0,2}$", version):
+        if not re.search(r"ubi[0-9]\.[0-9]{1,2}$|ubi[0-9]$", version):
             raise ValueError(
-                "Expect directories named in format ubi[0-9]{1}.?([0-9]{0,2})$', but got %s"
+                "Expect directories named in format ubi[0-9].([0-9]{1,2})$' or ubi[0-9]$, but got %s"
                 % version
             )
 

--- a/ubiconfig/_impl/loaders/local.py
+++ b/ubiconfig/_impl/loaders/local.py
@@ -40,15 +40,15 @@ class LocalLoader(object):
 
                 If version is None, we should get it from its path.
         """
-        if version is None:
-            # get version form path, such as configs/ubi7.1/config.yaml, get
-            # ubi7.1
-            version = os.path.basename(os.path.dirname(file_name))
-
         if not self._isroot:
             file_path = os.path.join(self._path, file_name)
         else:
             file_path = file_name
+
+        if version is None:
+            # get version from path, such as configs/ubi7.1/config.yaml, get
+            # ubi7.1
+            version = os.path.basename(os.path.dirname(file_path))
 
         LOG.info("Loading configuration file locally: %s", file_path)
 

--- a/ubiconfig/_impl/loaders/local.py
+++ b/ubiconfig/_impl/loaders/local.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 
 import yaml
 from jsonschema.exceptions import ValidationError
@@ -48,10 +49,12 @@ class LocalLoader(object):
         if version is None:
             # get version from path, such as configs/ubi7.1/config.yaml, get
             # ubi7.1.
-            # In a rare case, either path or filename doesn't include version
-            # info, i.e, pwd is '.', then we get version info by os.getcwd.
-            version = os.path.basename(os.path.dirname(file_path)) \
-                or os.path.basename(os.getcwd())
+            version = os.path.basename(os.path.dirname(os.path.abspath(file_path)))
+
+        if not re.search(r"ubi[0-9]{1}\.?[0-9]{0,2}$", version):
+            raise ValueError(
+                "Expect directories named in format ubi[0-9]{1}.?[0-9]{0,2}$, but got %s" % version
+            )
 
         LOG.info("Loading configuration file locally: %s", file_path)
 
@@ -97,7 +100,7 @@ class LocalLoader(object):
             ]
             if conf_files:
                 # if there's yaml files, then it must under some version directory
-                version = os.path.basename(root) or os.path.basename(os.getcwd())
+                version = os.path.basename(os.path.abspath(root))
                 ver_files_map.setdefault(version, []).extend(conf_files)
                 # the result map is as {'version': ['file1', 'file2', ..]}
 

--- a/ubiconfig/_impl/loaders/local.py
+++ b/ubiconfig/_impl/loaders/local.py
@@ -53,7 +53,8 @@ class LocalLoader(object):
 
         if not re.search(r"ubi[0-9]{1}\.?[0-9]{0,2}$", version):
             raise ValueError(
-                "Expect directories named in format ubi[0-9]{1}.?[0-9]{0,2}$, but got %s" % version
+                "Expect directories named in format ubi[0-9]{1}.?([0-9]{0,2})$', but got %s"
+                % version
             )
 
         LOG.info("Loading configuration file locally: %s", file_path)

--- a/ubiconfig/_impl/loaders/local.py
+++ b/ubiconfig/_impl/loaders/local.py
@@ -97,7 +97,7 @@ class LocalLoader(object):
             ]
             if conf_files:
                 # if there's yaml files, then it must under some version directory
-                version = os.path.basename(root)
+                version = os.path.basename(root) or os.path.basename(os.getcwd())
                 ver_files_map.setdefault(version, []).extend(conf_files)
                 # the result map is as {'version': ['file1', 'file2', ..]}
 


### PR DESCRIPTION
When version is None, it wrongly tries to get version from filename instead of the file path.