### PR TITLE
Retire python 2 support [RHELDST-15344]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,12 +35,10 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     install_requires=get_requirements(),
+    python_requires='>=3.6',
     project_urls={"Documentation": "https://release-engineering.github.io/ubi-config/"},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,pidiff,static,docs,py38,py39
+envlist = py36,pidiff,static,docs,py38,py39
 
 [testenv]
 deps=-rtest-requirements.txt


### PR DESCRIPTION
1.Remove python2-specific entries in 'classifiers' 2.Specify minimal python version to 3.6