### PR TITLE
Generic GitLab loader [RHELDST-19139]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     install_requires=get_requirements(),
-    python_requires='>=3.6',
+    python_requires=">=3.6",
     project_urls={"Documentation": "https://release-engineering.github.io/ubi-config/"},
 )

--- a/tests/ubiconfig/loaders/test_gitlab_loader.py
+++ b/tests/ubiconfig/loaders/test_gitlab_loader.py
@@ -42,4 +42,4 @@ def test_bad_yaml():
 
         # It should propagate the YAML load exception
         with pytest.raises(yaml.YAMLError):
-            loader.load("badfile.yaml")
+            loader.load("badfile.yaml", "ubi7")


### PR DESCRIPTION
Added support for generic (custom) names of branches
for GitlabLoader of ubi-config.

Removed also some hardcoded parts of code that were not
used in practice and were likely broken.

This change makes the `version` argument mandatory for `GitlabLoader.load()`
method even if it has currently default value set to None
(keeping the signature of overridden method). We can't easily guess what's
the default (fallback) branch in repository with multiple branches for each major version.

In practice we mostly rely on `load_all()` method that always provides
`version` arg in GitlabLoader.

This generic improvement is not supported for LocalLoader which is not
currently required for generic (non-ubi) config files.