### PR TITLE
Support for flags [RHELDST-18810]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for flags in config file
+
 ## [v2.3.0] - 2023-08-04
 
 ### Added

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -151,8 +151,13 @@ Loaded configuration files has to be presented in following format
     include:
     - name: <module-name>
       stream: <module-stream>
+  # Flags for interacting tools and services
+  flags:
+    flag_name_1: value
+    flag_name_2: value
 
 See also :py:meth:`~ubiconfig.Loader.load_all`, :py:meth:`~ubiconfig.Loader.load`, :py:meth:`~ubiconfig.get_loader`
+For supported flags refer to :ref:`config_schema`.
 
 .. _git_repo_format:
 
@@ -170,3 +175,16 @@ it has to be have following structure:
 
 See also: :ref:`yaml_format`
 
+
+.. _config_schema:
+
+JSON schema
+-----------
+
+This document shows the schema of ubi config files supported by this library,
+in `JSON schema`_ format.
+
+.. include:: ../ubi-config/utils/config_schema.json
+    :code: json
+
+.. _JSON schema: https://json-schema.org/

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="ubi-config",
-    version="2.3.0",
+    version="3.0.0",
     author="",
     author_email="",
     packages=find_packages(exclude=["tests", "tests.*"]),

--- a/tests/data/configs/ubi7.1/rhel-atomic-host.yaml
+++ b/tests/data/configs/ubi7.1/rhel-atomic-host.yaml
@@ -40,3 +40,6 @@ modules:
     stream: 10
   - name: something-else
     stream: 1.10
+
+flags:
+  base_pkgs_only: false

--- a/tests/ubiconfig/config_types/test_config_types.py
+++ b/tests/ubiconfig/config_types/test_config_types.py
@@ -1,4 +1,6 @@
-from ubiconfig.config_types import packages, modules, content_sets
+import pytest
+
+from ubiconfig.config_types import packages, modules, content_sets, flags
 
 
 def test_package_with_arch():
@@ -96,3 +98,21 @@ def test_content_sets():
         ),
     }
     assert expected_exported_dict == css.export_dict()
+
+
+@pytest.mark.parametrize(
+    ("flag, input_val, output_val"),
+    [
+        ("flag_1", True, True),
+        ("flag_2", "some-value", "some-value"),
+        ("flag_3", "faLse", False),
+        ("flag_4", "True", True),
+    ],
+)
+def test_flags(flag, input_val, output_val):
+    data = {flag: input_val}
+
+    parsed_flags = flags.Flags.load_from_dict(data)
+
+    assert getattr(parsed_flags, flag).name == flag
+    assert getattr(parsed_flags, flag).value == output_val

--- a/tests/ubiconfig/test_ubi.py
+++ b/tests/ubiconfig/test_ubi.py
@@ -458,3 +458,4 @@ def test_ubi_config(ubi7_1_config_file1):
     assert config.content_sets.rpm.input == "rhel-atomic-host-rpms"
     assert str(config.packages.blacklist[0]) == "<Package: kernel*>"
     assert config.version == "7.1"
+    assert config.flags.base_pkgs_only.value is False

--- a/tests/ubiconfig/utils/test_validation.py
+++ b/tests/ubiconfig/utils/test_validation.py
@@ -49,3 +49,15 @@ def test_validate_failed_wrong_data_type(ubi7_1_config):
     ubi7_1_config["packages"]["include"] = "A string"
     with pytest.raises(ValidationError):
         config_validation.validate_config(ubi7_1_config)
+
+
+def test_validate_failed_wrong_data_type_flags(ubi7_1_config):
+    ubi7_1_config["flags"]["base_pkgs_only"] = 120
+    with pytest.raises(ValidationError):
+        config_validation.validate_config(ubi7_1_config)
+
+
+def test_validate_failed_unsupported_flag(ubi7_1_config):
+    ubi7_1_config["flags"] = {"unsupported-flag": True}
+    with pytest.raises(ValidationError):
+        config_validation.validate_config(ubi7_1_config)

--- a/ubiconfig/config_types/__init__.py
+++ b/ubiconfig/config_types/__init__.py
@@ -1,6 +1,7 @@
 from .modules import Modules
 from .packages import Packages
 from .content_sets import ContentSetsMapping
+from .flags import Flags
 
 
 class UbiConfig(object):
@@ -16,18 +17,20 @@ class UbiConfig(object):
       config.content_sets.rpm.input
       config.content_sets.debuginfo.output"""
 
-    def __init__(self, cs, pkgs, mds, file_name, version):
+    def __init__(self, cs, pkgs, mds, file_name, version, flags):
         """
         :param cs: :class:`~ubiconfig.config_types.content_sets.ContentSetsMapping`
         :param pkgs: :class:`~ubiconfig.config_types.packages.Packages`
         :param mds: :class:`~ubiconfig.config_types.modules.Modules`
         :param filename: filename used as identifier
+        :param flags: :class:`~ubiconfig.config_types.flags.Flags`
         """
         self.content_sets = cs
         self.packages = pkgs
         self.modules = mds
         self.file_name = file_name
         self.version = version
+        self.flags = flags
 
     def __repr__(self):
         return self.file_name
@@ -58,9 +61,16 @@ class UbiConfig(object):
             pkgs.get("include", []), pkgs.get("exclude", []), data.get("arches", [])
         )
         cs_map = ContentSetsMapping.load_from_dict(data["content_sets"])
+
+        flags = Flags.load_from_dict(data.get("flags", {}))
         # use the simplified file name
         file_name = file_name.split("/")[-1]
 
         return cls(
-            cs=cs_map, pkgs=pkgs_data, mds=m_data, file_name=file_name, version=version
+            cs=cs_map,
+            pkgs=pkgs_data,
+            mds=m_data,
+            file_name=file_name,
+            version=version,
+            flags=flags,
         )

--- a/ubiconfig/config_types/flags.py
+++ b/ubiconfig/config_types/flags.py
@@ -1,0 +1,49 @@
+class Flag:
+    def __init__(self, name, value):
+        self.name = name
+        self.value = _str_to_bool(value)
+
+
+class Flags(object):
+    """group of modules"""
+
+    def __init__(self, flags):
+        """
+        Args:
+            include(list): a list of :class:`Flag` instances
+        """
+        self.flags = flags
+
+    def __getattr__(self, name):
+        # allow getting flags as object attrs
+        for item in self.flags:
+            if item.name == name:
+                return item
+
+    @classmethod
+    def load_from_dict(cls, data):
+        """Create instances of :class:`Flags` from a dictionary
+
+        Args:
+            data(dict): dictionary with data of following format
+
+        .. code-block:: json
+
+            {
+                "flag_1": "value",
+                "flag_2": "value"
+            }
+        """
+        return cls([Flag(name, value) for name, value in data.items()])
+
+
+def _str_to_bool(value):
+    out = value
+
+    if isinstance(value, str):
+        if value.lower() in ("true", "yes"):
+            out = True
+        elif value.lower() in ("false", "no"):
+            out = False
+
+    return out

--- a/ubiconfig/utils/config_schema.json
+++ b/ubiconfig/utils/config_schema.json
@@ -62,6 +62,14 @@
                 },
             "additionalProperties": false,
             "required": ["include"]
+            },
+        "flags": {
+            "type": "object",
+            "properties": {
+                "base_pkgs_only": {"type": ["string", "boolean"],
+                                   "$comment": "Include only packages defined in config file."}
+                },
+            "additionalProperties": false
             }
         },
     "additionalProperties": false,


### PR DESCRIPTION
Added support for flags to be present in ubi-config files. They can be defined as a dictionary under the `flags` field in the config file.

These flags can be used in various tools that use ubi-config library.

This commit adds support for flag `base_pkgs_only` that will tell ubi-manifest service to include only the pkgs that are defined in the config file and nothing else.