### PR TITLE
Match behavior of local loader to the GitLab loader [RHELDST-22489]

### DIFF
--- a/tests/data/configs/test-prefix12.13/test-config.yaml
+++ b/tests/data/configs/test-prefix12.13/test-config.yaml
@@ -1,0 +1,21 @@
+content_sets:
+  # This defines the mapping between UBI content sets and underlying content sets
+  rpm:
+    output: ubi-7-server-rpms
+    input: rhel-7-server-rpms
+  srpm:
+    output: ubi-7-server-source-rpms
+    input: rhel-7-server-source-rpms
+  debuginfo:
+    output: ubi-7-server-debug-rpms
+    input: rhel-7-server-debug-rpms
+
+arches:
+ - src
+ - x86_64
+packages:
+  include:
+  - foo.*
+  # Blacklist of packages to exclude
+  exclude:
+  - bar

--- a/tests/ubiconfig/test_ubi.py
+++ b/tests/ubiconfig/test_ubi.py
@@ -180,13 +180,20 @@ def test_load_all_with_error_config(
     assert len(configs) == 4
 
 
-def test_load_from_local():
-    path = os.path.join(TEST_DATA_DIR, "configs/ubi7.1")
+@pytest.mark.parametrize(
+    "path, expected_version, filename",
+    [
+        ("configs/ubi7.1", "7.1", "rhel-atomic-host.yaml"),
+        ("configs/test-prefix12.13", "12.13", "test-config.yaml"),
+    ],
+)
+def test_load_from_local(path, expected_version, filename):
+    path = os.path.join(TEST_DATA_DIR, path)
     loader = ubi.get_loader(path)
     # loads relative to given path
-    config = loader.load("rhel-atomic-host.yaml")
+    config = loader.load(filename)
     assert isinstance(config, UbiConfig)
-    assert config.version == "7.1"
+    assert config.version == expected_version
 
 
 def test_load_from_local_decimal_integrity():
@@ -232,14 +239,14 @@ def test_load_all_from_local_with_error_configs():
     loader = ubi.get_loader(TEST_DATA_DIR)
     configs = loader.load_all()
 
-    assert len(configs) == 4
+    assert len(configs) == 5
 
 
 def test_load_all_from_local_recursive():
     repo = os.path.join(TEST_DATA_DIR, "configs")
     loader = ubi.get_loader(repo)
     configs = loader.load_all()
-    assert len(configs) == 4
+    assert len(configs) == 5
     assert isinstance(configs[0], UbiConfig)
     for conf in configs:
         # version should be populated

--- a/ubiconfig/_impl/loaders/base.py
+++ b/ubiconfig/_impl/loaders/base.py
@@ -1,3 +1,10 @@
+import re
+
+PREFIX_VERSION_RE = re.compile(
+    r"^(?P<prefix>[A-Za-z_-]{1,25})(?P<default_version>[\d]{1,2})(\.(?P<minor_version>[\d]{1,2}))?$"
+)
+
+
 class Loader(object):
     """Load UBI configuration.
 

--- a/ubiconfig/_impl/loaders/gitlab.py
+++ b/ubiconfig/_impl/loaders/gitlab.py
@@ -12,11 +12,9 @@ from ubiconfig.utils.api.gitlab import RepoApi
 from ubiconfig.utils.config_validation import validate_config
 from ubiconfig.config_types import UbiConfig
 
-from .base import Loader
+from .base import Loader, PREFIX_VERSION_RE
 
 LOG = logging.getLogger("ubiconfig")
-
-BRANCH_RE = re.compile(r"^(?P<prefix>[\w-]{1,25})(?P<default_version>[\d]{1,2})")
 
 GITLAB_RETRIES = int(os.getenv("UBICONFIG_GITLAB_RETRIES", "5"))
 GITLAB_BACKOFF = float(os.getenv("UBICONFIG_GITLAB_BACKOFF", "0.5"))
@@ -84,7 +82,7 @@ class GitlabLoader(Loader):
                 "Couldn't find file %s from remote repo %s" % (file_name, self._url)
             )
 
-        match = re.match(BRANCH_RE, version)
+        match = re.match(PREFIX_VERSION_RE, version)
         if not match:
             raise ValueError("Invalid version (branch name) %s" % version)
 

--- a/ubiconfig/utils/api/gitlab.py
+++ b/ubiconfig/utils/api/gitlab.py
@@ -1,4 +1,5 @@
 """provide gitlab api used to read repositories"""
+
 import os
 import re
 


### PR DESCRIPTION
This change improves local loader in a way that
it can load directory with custom prefix so it's not limited to start with 'ubi' string.

Also it fixes RE that matches 'prefix-version' so it can match also double digit major (default) version.